### PR TITLE
Fix app extension bundle ID mismatch

### DIFF
--- a/CallerLookup/CallerLookup.xcodeproj/project.pbxproj
+++ b/CallerLookup/CallerLookup.xcodeproj/project.pbxproj
@@ -463,7 +463,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.callerlookup.CallerLookupExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.callerlookup.CallerLookup.CallerLookupExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -489,7 +489,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.callerlookup.CallerLookupExtension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.callerlookup.CallerLookup.CallerLookupExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
The CallerLookupExtension bundle ID was set to com.callerlookup.CallerLookupExtension, which caused an installation error on iOS Simulator. iOS requires app extension bundle IDs to start with the parent app's bundle ID followed by a dot.

Changed: com.callerlookup.CallerLookupExtension
To: com.callerlookup.CallerLookup.CallerLookupExtension

This resolves the "Mismatched bundle IDs" error (IXErrorDomain Code: 2).